### PR TITLE
Properly assign log levels

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ function logger(winstonInstance) {
     if (ctx.status >= 500) {
       logLevel = 'error';
     }
-    if (ctx.status >= 400) {
+    else if (ctx.status >= 400) {
       logLevel = 'warn';
     }
-    if (ctx.status >= 100) {
+    else if (ctx.status >= 100) {
       logLevel = 'info';
     }
 


### PR DESCRIPTION
Previously all log levels were being set to "info".